### PR TITLE
Add flight behaviour

### DIFF
--- a/src/com/arcvega/simulation/agents/Agent.java
+++ b/src/com/arcvega/simulation/agents/Agent.java
@@ -23,6 +23,18 @@ public abstract class Agent implements Steppable {
    * @param sim Simulation containing all agents
    */
   void randomWalk(Simulation sim) {
+    randomWalk(sim, 1.0);
+  }
+
+
+  /**
+   * Randomly walks the agent and scales the resultant vector by {@param vecScalar}
+   *
+   * @param sim       Simulation containing agent
+   * @param vecScalar Scalar by which vector will be adjusted
+   */
+  void randomWalk(Simulation sim, double vecScalar) {
+
     Double2D location = sim.space.getObjectLocation(this);
     MutableDouble2D modifier;
 
@@ -38,13 +50,17 @@ public abstract class Agent implements Steppable {
     }
 
     //Every time decision return true, they are pulled to the centre slightly
-    if (decision(sim, SimConfig.PROBABILTY_TO_BE_PULLED_TO_CENTRE)) {
+    if (decision(sim, SimConfig.PROBABILITY_TO_BE_PULLED_TO_CENTRE)) {
       modifier
-          .addIn((SimConfig.SIM_HEIGHT / 2.0 - location.getX()) * SimConfig.INTENSITY_OF_PULL_TO_CENTRE,
-              (SimConfig.SIM_WIDTH / 2.0 - location.getY()) * SimConfig.INTENSITY_OF_PULL_TO_CENTRE);
+          .addIn((SimConfig.SIM_HEIGHT / 2.0 - location.getX())
+                  * SimConfig.INTENSITY_OF_PULL_TO_CENTRE,
+              (SimConfig.SIM_WIDTH / 2.0 - location.getY())
+                  * SimConfig.INTENSITY_OF_PULL_TO_CENTRE);
     }
 
-    modifier.resize(1);
+    if (modifier.length() != 0) {
+      modifier.resize(vecScalar);
+    }
 
     Double2D newLocation = new Double2D(location.getX() + modifier.getX(),
         location.getY() + modifier.getY());
@@ -55,7 +71,8 @@ public abstract class Agent implements Steppable {
 
   /**
    * Function that gets a unit vector in the direction of an agent
-   * @param sim Sim object
+   *
+   * @param sim   Simulation object
    * @param agent Agent to move towards
    * @return A unit vector in the direction of {@param agent}
    */
@@ -65,8 +82,9 @@ public abstract class Agent implements Steppable {
 
   /**
    * Function that gets a vector in the direction of an agent with length {@param scalar}
-   * @param sim Sim object
-   * @param agent Agent to move towards
+   *
+   * @param sim    Sim object
+   * @param agent  Agent to move towards
    * @param scalar Length of vector
    * @return A vector in the direction of {@param agent}
    */
@@ -87,13 +105,32 @@ public abstract class Agent implements Steppable {
 
   /**
    * Returns True n times where n is given by {@param probability}
-   * @param state Simulation Containing all agents
+   *
+   * @param state       Simulation Containing all agents
    * @param probability The probability that True is returned
    * @return Value depending outcome dictated by {@param probability}
    */
   private boolean decision(Simulation state, double probability) {
     double random = state.random.nextDouble();
     return random <= probability;
+  }
+
+
+  /**
+   * Follow an agent denoted by {@param agentToFollow} and stay within the {@param minSeparation}
+   * distance
+   *
+   * @param sim           Simulation containing agents
+   * @param agentToFollow The agent who I will follow
+   * @param maxSeparation The maximum distance for the agent to stray away from the partner
+   */
+  private void coupledWalk(Simulation sim, Agent agentToFollow, double maxSeparation) {
+    if (sim.space.getObjectLocation(this).distance(sim.space.getObjectLocation(agentToFollow))
+        > maxSeparation) {
+      walkTowards(sim, getVectorToAgent(sim, agentToFollow));
+    } else {
+      randomWalk(sim);
+    }
   }
 
 

--- a/src/com/arcvega/simulation/agents/Casey.java
+++ b/src/com/arcvega/simulation/agents/Casey.java
@@ -26,7 +26,11 @@ public class Casey extends Agent {
   @Override
   public void step(SimState simState) {
     Simulation sim = (Simulation) simState;
-    randomWalk(sim); // Only does random walk for now
+    if (!isCoupled()) {
+      randomWalk(sim); // Only does random walk for now
+    } else {
+      coupledWalk(sim);
+    }
   }
 
 
@@ -58,12 +62,7 @@ public class Casey extends Agent {
    * @param sim Simulation containing agents
    */
   private void coupledWalk(Simulation sim) {
-    if (sim.space.getObjectLocation(this).distance(sim.space.getObjectLocation(coupledMatt))
-        > SimConfig.CASEY_MINIMUM_COUPLING_DISTANCE) {
-      walkTowards(sim, getVectorToAgent(sim, coupledMatt));
-    } else {
-      randomWalk(sim);
-    }
+    randomWalk(sim, SimConfig.FLIGHT_RESPONSE);
   }
 
   /**

--- a/src/com/arcvega/simulation/agents/Matt.java
+++ b/src/com/arcvega/simulation/agents/Matt.java
@@ -67,9 +67,9 @@ public class Matt extends Agent {
   private void coupledWalk(Simulation sim) {
     if (sim.space.getObjectLocation(this).distance(sim.space.getObjectLocation(coupledCasey))
         > SimConfig.CASEY_MINIMUM_COUPLING_DISTANCE) {
-      walkTowards(sim, getVectorToAgent(sim, coupledCasey));
+      walkTowards(sim, getVectorToAgent(sim, coupledCasey, SimConfig.FLIGHT_RESPONSE));
     } else {
-      randomWalk(sim);
+      randomWalk(sim, SimConfig.FLIGHT_RESPONSE);
     }
   }
 
@@ -140,6 +140,10 @@ public class Matt extends Agent {
 
   public void setCoupledCasey(Casey casey) {
     coupledCasey = casey;
+  }
+
+  public Casey getCoupledCasey() {
+    return coupledCasey;
   }
 
   public boolean isCoupled() {

--- a/src/com/arcvega/simulation/config/SimConfig.java
+++ b/src/com/arcvega/simulation/config/SimConfig.java
@@ -13,7 +13,7 @@ public class SimConfig {
   /**Height of the 2D space */
   public static final double INTENSITY_OF_PULL_TO_CENTRE = 0.1;
   /**Height of the 2D space */
-  public static final double PROBABILTY_TO_BE_PULLED_TO_CENTRE = 0.01;
+  public static final double PROBABILITY_TO_BE_PULLED_TO_CENTRE = 0.01;
 
   /**Amount of CASEY agents in the simulation*/
   public static final int CASEY_AMOUNT = 200;
@@ -35,4 +35,8 @@ public class SimConfig {
   public static final double MATT_THRESHOLD_DISTANCE = 10;
   /**Minimum distance needed for MATT to couple with CASEY*/
   public static final double MATT_MINIMUM_COUPLING_DISTANCE = 15;
+
+
+  /**Scalar which dictates flight response for now*/
+  public static final double FLIGHT_RESPONSE = 2.0; // TODO: This will eventually be done by genetics
 }


### PR DESCRIPTION
Matt and Casey will now get a speed boost once they are paired

Overloaded random walk to prevent having duplicate code since it can now take a scalar argument similar to `getVectorToAgent()` 

Speed boost is currently dictated by the config file, but this can be changed to genetics later on

## Description of code in PR

### Quick Checklist:

1. [x] Does the code compile?
2. [x] Did you lint the code?
3. [ ] Have you added tests and do all tests pass?

Zooming is now enabled and allows Matt and Casey to get ahead of Jim